### PR TITLE
cobbler: add net.ifnames=0 in the bootstrap kernel parameters

### DIFF
--- a/deployment/puppet/nailgun/manifests/cobbler.pp
+++ b/deployment/puppet/nailgun/manifests/cobbler.pp
@@ -168,7 +168,7 @@ class nailgun::cobbler(
         distro => "bootstrap",
         menu => true,
         kickstart => "",
-        kopts => "biosdevname=0 url=http://${::fuel_settings['ADMIN_NETWORK']['ipaddress']}:8000/api mco_user=${mco_user} mco_pass=${mco_pass}",
+        kopts => "biosdevname=0 net.ifnames=0 url=http://${::fuel_settings['ADMIN_NETWORK']['ipaddress']}:8000/api mco_user=${mco_user} mco_pass=${mco_pass}",
         ksmeta => "",
         server => $real_server,
         require => Cobbler_distro["bootstrap"],


### PR DESCRIPTION
Currently nailgun-agent only recognizes network interfaces with device
name like "ethX" so we should disable consistent network device naming
in the bootstrap environment, so that nailgun-agent can report correct
network devices information to fuel server.

Fixes: redmine #3187

Signed-off-by: huntxu mhuntxu@gmail.com
