### PR TITLE
Multibackend support for ceph

### DIFF
--- a/deployment/puppet/openstack/manifests/cinder.pp
+++ b/deployment/puppet/openstack/manifests/cinder.pp
@@ -174,10 +174,14 @@ class openstack::cinder(
       }
       'ceph': {
         Ceph::Pool<| title == $::ceph::cinder_pool |> ->
-        class {'cinder::volume::rbd':
-          rbd_pool        => $::ceph::cinder_pool,
-          rbd_user        => $::ceph::cinder_user,
-          rbd_secret_uuid => $::ceph::rbd_secret_uuid,
+        cinder::backend::rbd {'cinder_ceph':
+          rbd_pool            => $::ceph::cinder_pool,
+          rbd_user            => $::ceph::cinder_user,
+          rbd_secret_uuid     => $::ceph::rbd_secret_uuid,
+          volume_backend_name => 'cinder_ceph',
+        }
+        class {'cinder::backends':
+          enabled_backends    => ['cinder_ceph'],
         }
       }
     }

--- a/deployment/puppet/openstack/manifests/controller.pp
+++ b/deployment/puppet/openstack/manifests/controller.pp
@@ -478,6 +478,16 @@ class openstack::controller (
         idle_timeout         => $idle_timeout,
         ceilometer           => $ceilometer,
       } # end class
+
+      if ($manage_volumes == 'ceph') {
+        class {'openstack::create_vol_types':
+          set_type  => 'rbd',
+          set_key   => 'volume_backend_name',
+          set_value => 'cinder_ceph',
+          require   => [Class['openstack::cinder'], Class['cinder::keystone::auth']]
+        }
+      } # end volumes-ceph
+
     } else { # defined
       if $manage_volumes {
       # Set up nova-volume

--- a/deployment/puppet/openstack/manifests/create_vol_types.pp
+++ b/deployment/puppet/openstack/manifests/create_vol_types.pp
@@ -1,0 +1,52 @@
+# == Class: openstack::create_vol_types
+#
+# Creates Cinder Multibackend vol types.
+#
+# === Parameters
+#
+# [*set_type*]
+#   (required) volume type to be created.
+# [*set_key*]
+#   (required) set_key
+# [*set_value*]
+#   (required) set_value
+
+include cinder::params
+
+class openstack::create_vol_types(
+  $set_type,
+  $set_key,
+  $set_value,
+) {
+    $os_username = $::fuel_settings['access']['user']
+    $os_password = $::fuel_settings['access']['password']
+    $os_tenant_name = $::fuel_settings['access']['tenant']
+    $os_auth_url = "http://${::fuel_settings['management_vip']}:5000/v2.0/"
+
+    $primary_controller = $::fuel_settings['role'] ? { 'primary-controller'=>true, default=>false }
+
+    if $primary_controller {
+      exec {"waiting for cinder service":
+        path        => '/usr/bin',
+        command     => 'cinder --retries 10 type-list',
+        tries       => 10,
+        try_sleep   => 1,
+        timeout     => 600,
+        environment => [
+          "OS_TENANT_NAME=${os_tenant_name}",
+          "OS_USERNAME=${os_username}",
+          "OS_PASSWORD=${os_password}",
+          "OS_AUTH_URL=${os_auth_url}",
+        ],
+        require     => Package['python-cinderclient']
+      } ->
+      cinder::type { $set_type:
+        os_username     => $os_username,
+        os_password     => $os_password,
+        os_tenant_name  => $os_tenant_name,
+        os_auth_url     => $os_auth_url,
+        set_key         => $set_key,
+        set_value       => $set_value,
+      }
+    }
+  }


### PR DESCRIPTION
1. alter ceph configuration in cinder to support multi-backend.
2. create new create_vol_types class.
3. use create_vol_types in controller.pp to create rbd vol-type.
