### PR TITLE
set same cinder host for all controller nodes to support cinder-volume ha

### DIFF
--- a/deployment/puppet/cinder/manifests/backend/rbd.pp
+++ b/deployment/puppet/cinder/manifests/backend/rbd.pp
@@ -71,7 +71,6 @@ define cinder::backend::rbd (
     "${name}/rbd_pool":                         value => $rbd_pool;
     "${name}/rbd_max_clone_depth":              value => $rbd_max_clone_depth;
     "${name}/rbd_flatten_volume_from_snapshot": value => $rbd_flatten_volume_from_snapshot;
-    "${name}/host":                             value => "rbd:${rbd_pool}";
   }
 
   if $rbd_secret_uuid {

--- a/deployment/puppet/openstack/manifests/cinder.pp
+++ b/deployment/puppet/openstack/manifests/cinder.pp
@@ -115,6 +115,11 @@ class openstack::cinder(
     }
   }
 
+  ####### Set all cinder host to 'cinder' #######
+  cinder_config {
+    'DEFAULT/host':   value => 'cinder';
+  }
+
   if ($bind_host) {
     class { 'cinder::api':
       keystone_enabled   => $keystone_enabled,


### PR DESCRIPTION
All cinder-volume processes on controller nodes need a same host value to support ha.
We  set this host value in cinder.conf DEFAULT section, for ceph and eqlx too.
The host option in ceph section is not needed now.

Signed-off-by: apporc appleorchard2000@gmail.com
