### PR TITLE
ceph: do not log all msg to rgw_log_file

### DIFF
--- a/deployment/puppet/ceph/manifests/conf.pp
+++ b/deployment/puppet/ceph/manifests/conf.pp
@@ -30,8 +30,7 @@ class ceph::conf {
       'global/osd_pool_default_pgp_num':           value => $::ceph::osd_pool_default_pgp_num;
       'global/cluster_network':                    value => $::ceph::cluster_network;
       'global/public_network':                     value => $::ceph::public_network;
-      'global/log_file':                           value => $::ceph::rgw_log_file;
-      'global/log_to_syslog':                      value => $::ceph::use_syslog;
+      'global/log_to_syslog':                      value => false;
       'global/log_to_syslog_level':                value => $::ceph::syslog_log_level;
       'global/log_to_syslog_facility':             value => $::ceph::syslog_log_facility;
       'client/rbd cache':                          value => true;


### PR DESCRIPTION
1. do not set all log file to rgw_log_file
2. do not log to syslog

Signed-off-by: Dunrong Huang dunrong.huang@eayun.com
