### PR TITLE
glance: python-ceph no longer exists, use python-ceph-compat instead.

### DIFF
--- a/deployment/puppet/glance/manifests/params.pp
+++ b/deployment/puppet/glance/manifests/params.pp
@@ -3,7 +3,7 @@
 class glance::params {
 
   $client_package_name = 'python-glanceclient'
-  $pyceph_package_name = 'python-ceph'
+  $pyceph_package_name = 'python-ceph-compat'
 
   $cache_cleaner_command = 'glance-cache-cleaner'
   $cache_pruner_command  = 'glance-cache-pruner'


### PR DESCRIPTION
Signed-off-by: Zhao Chao zhaochao1984@gmail.com
