### PR TITLE
redmine #4391

### DIFF
--- a/deployment/puppet/osnailyfacter/manifests/cluster_ha.pp
+++ b/deployment/puppet/osnailyfacter/manifests/cluster_ha.pp
@@ -712,7 +712,7 @@ class osnailyfacter::cluster_ha {
         disk_allocation_ratio      => '1.0',
         ram_allocation_ratio       => '1.0',
         scheduler_host_subset_size => '30',
-        scheduler_default_filters  => concat($scheduler_default_filters, [ 'RetryFilter', 'AvailabilityZoneFilter', 'RamFilter', 'CoreFilter', 'DiskFilter', 'ComputeFilter', 'ComputeCapabilitiesFilter', 'ImagePropertiesFilter', 'ServerGroupAntiAffinityFilter', 'ServerGroupAffinityFilter' ])
+        scheduler_default_filters  => concat($scheduler_default_filters, [ 'AggregateMultiTenancyIsolation', 'AggregateInstanceExtraSpecsFilter', 'RetryFilter', 'AvailabilityZoneFilter', 'RamFilter', 'CoreFilter', 'DiskFilter', 'ComputeFilter', 'ComputeCapabilitiesFilter', 'ImagePropertiesFilter', 'ServerGroupAntiAffinityFilter', 'ServerGroupAffinityFilter' ])
       }
 
       # From logasy filter.pp

--- a/deployment/puppet/osnailyfacter/manifests/cluster_simple.pp
+++ b/deployment/puppet/osnailyfacter/manifests/cluster_simple.pp
@@ -405,7 +405,7 @@ class osnailyfacter::cluster_simple {
         disk_allocation_ratio      => '1.0',
         ram_allocation_ratio       => '1.0',
         scheduler_host_subset_size => '30',
-        scheduler_default_filters  => concat($scheduler_default_filters, [ 'RetryFilter', 'AvailabilityZoneFilter', 'RamFilter', 'CoreFilter', 'DiskFilter', 'ComputeFilter', 'ComputeCapabilitiesFilter', 'ImagePropertiesFilter', 'ServerGroupAntiAffinityFilter', 'ServerGroupAffinityFilter' ])
+        scheduler_default_filters  => concat($scheduler_default_filters, [ 'AggregateMultiTenancyIsolation', 'AggregateInstanceExtraSpecsFilter', 'RetryFilter', 'AvailabilityZoneFilter', 'RamFilter', 'CoreFilter', 'DiskFilter', 'ComputeFilter', 'ComputeCapabilitiesFilter', 'ImagePropertiesFilter', 'ServerGroupAntiAffinityFilter', 'ServerGroupAffinityFilter' ])
       }
 
       # From logasy filter.pp


### PR DESCRIPTION
Enable AggregateMultiTenancyIsolation and AggregateInstanceExtraSpecsFilter for nova scheduler by default.

Signed-off-by: apporc appleorchard2000@gmail.com
