### PR TITLE
ceilometer: don't add duplicate notification driver for neutron

### DIFF
--- a/deployment/puppet/openstack/manifests/ceilometer.pp
+++ b/deployment/puppet/openstack/manifests/ceilometer.pp
@@ -107,10 +107,6 @@ class openstack::ceilometer (
 
     class { '::ceilometer::agent::notification': }
 
-    if $use_neutron {
-      neutron_config { 'DEFAULT/notification_driver': value => 'messaging' }
-    }
-
     if $ha_mode {
       include ceilometer_ha::agent::central
 


### PR DESCRIPTION
By default RDO neutron package has already set the needed configuration
in neutron-dist.conf, adding the same notification again would make
neutron notify twice and then ceilomter receive duplicate messages.

Either changing neutron-dist.conf in neutron package or changing
ceilometer deployment puppet would solve the problem and we choose the
latter.

Fixes: redmine #6168

Signed-off-by: huntxu mhuntxu@gmail.com
