### PR TITLE
network: sync neutron's verbose configuration with others

### DIFF
--- a/deployment/puppet/openstack/manifests/network.pp
+++ b/deployment/puppet/openstack/manifests/network.pp
@@ -131,8 +131,7 @@ class openstack::network (
 
       Sysctl::Value<| name == 'net.ipv4.ip_forward' |> -> Neutron_config<||>
       class {'::neutron':
-        # FIXME: add verbose option back into upstream neutron module
-        #verbose                 => $verbose,
+        verbose                 => $verbose,
         debug                   => $debug,
         use_syslog              => $use_syslog,
         log_facility            => $syslog_log_facility,


### PR DESCRIPTION
This is needed for lma monitor.

Fixes: redmine #6167

Signed-off-by: huntxu mhuntxu@gmail.com
