### PR TITLE
change horizon listen port from 80 to 8080

### DIFF
--- a/deployment/puppet/horizon/manifests/init.pp
+++ b/deployment/puppet/horizon/manifests/init.pp
@@ -38,7 +38,7 @@ class horizon(
   $django_debug          = false,
   $django_verbose        = false,
   $api_result_limit      = 1000,
-  $http_port             = 80,
+  $http_port             = 8080,
   $https_port            = 443,
   $use_ssl               = false,
   $log_level             = 'WARNING',

--- a/deployment/puppet/openstack/manifests/ha/horizon.pp
+++ b/deployment/puppet/openstack/manifests/ha/horizon.pp
@@ -5,7 +5,7 @@ class openstack::ha::horizon (
 
   openstack::ha::haproxy_service { 'horizon':
     order          => '015',
-    listen_port    => 80,
+    listen_port    => 8080,
     public         => true,
     internal       => false,
     define_cookies => true,


### PR DESCRIPTION
eayuncenter use 80 port to provide web service.

Signed-off-by: blkart <blkart.org@gmail.com>