### PR TITLE
rabbitmq: change clone resource to be ordered.

### DIFF
--- a/deployment/puppet/nova/manifests/rabbitmq.pp
+++ b/deployment/puppet/nova/manifests/rabbitmq.pp
@@ -142,6 +142,9 @@ class nova::rabbitmq(
             'set_policy'       => "\'ha-all \".\" {\"ha-mode\":\"all\",\"ha-sync-mode\":\"automatic\"}\'"
           },
           complex_type => 'clone',
+          ms_metadata => {
+            'ordered' => 'true'
+          },
           operations => {
             'monitor' => {
               'interval' => '30',


### PR DESCRIPTION
As we use clone resource to start rabbitmq cluster, when all rabbitmq
instances start simultaneously, rabbitmq cluster will be partitioned.
Change the clone resource to be ordered, the rabbitmq instances will
start in series, and fix the problem.

Signed-off-by: Zhao Chao <zhaochao1984@gmail.com>