### PR TITLE
set memcached_servers in nova.conf on compute node

### DIFF
--- a/deployment/puppet/osnailyfacter/manifests/cluster_simple.pp
+++ b/deployment/puppet/osnailyfacter/manifests/cluster_simple.pp
@@ -572,6 +572,7 @@ class osnailyfacter::cluster_simple {
         nova_report_interval           => $::nova_report_interval,
         nova_service_down_time         => $::nova_service_down_time,
         cinder_rate_limits             => $::cinder_rate_limits,
+        cache_server_ip                => [$controller_node_address],
       }
       nova_config { 'DEFAULT/resume_guests_state_on_host_boot': value => $::fuel_settings['resume_guests_state_on_host_boot'] }
       nova_config { 'DEFAULT/use_cow_images': value => $::fuel_settings['use_cow_images'] }


### PR DESCRIPTION
In multinode deploy method, nova service on compute node need connect
to memcached service of controller node.

redmine #11301

Signed-off-by: blkart <blkart.org@gmail.com>